### PR TITLE
Filters on base URL

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -38,7 +38,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$stylesheets = array();
-		$siteurl = apply_filters( 'ngx_http_concat_site_url', site_url() );
+		$siteurl = apply_filters( 'ngx_http_concat_site_url', $this->base_url );
 
 		$this->all_deps( $handles );
 

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -38,7 +38,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$stylesheets = array();
-		$siteurl = site_url();
+		$siteurl = apply_filters( 'ngx_http_concat_site_url', site_url() );
 
 		$this->all_deps( $handles );
 

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -38,7 +38,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts= array();
-		$siteurl = site_url();
+		$siteurl = apply_filters( 'ngx_http_concat_site_url', site_url() );
 
 		$this->all_deps( $handles );
 		$level = 0;

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -38,7 +38,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 	function do_items( $handles = false, $group = false ) {
 		$handles = false === $handles ? $this->queue : (array) $handles;
 		$javascripts= array();
-		$siteurl = apply_filters( 'ngx_http_concat_site_url', site_url() );
+		$siteurl = apply_filters( 'ngx_http_concat_site_url', $this->base_url );
 
 		$this->all_deps( $handles );
 		$level = 0;


### PR DESCRIPTION
CDN plugins may change the script/style loader path to point to a CDN domain, which causes concatenation (and therefore, minification) to fail when the concatenation script makes checks to skip external assets.

See https://github.com/ethitter/nginx-http-concat/blob/bc6244b7526e1d5fef0a69d8b60d4ee09ddb8796/cssconcat.php#L75 and https://github.com/ethitter/nginx-http-concat/blob/bc6244b7526e1d5fef0a69d8b60d4ee09ddb8796/jsconcat.php#L75 for the relevant checks.

Core's implementation of `WP_Scripts` and `WP_Styles` uses a `base_url` property that is set when the `$wp_scripts` and `$wp_styles` globals are prepared. Through magic methods, this property can be changed by a CDN plugin. Since this plugin calls `site_url()` without any opportunity to modify (outside of filtering on `site_url`, which introduces a host of timing and other issues), plugins don't have an opportunity to match the "site url" to the asset source if a CDN plugin is present.

CDN plugins can't skip rewriting the asset tags when this plugin is present, as any asset that fails the `$do_concat` check within this plugin would then bypass the CDN.

Adding these filters easily overcomes these issues.
