### PR TITLE
jsconcat: don't concat scripts with associated inline scripts

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -86,9 +86,10 @@ class WPcom_JS_Concat extends WP_Scripts {
 
 			//Don't concat items with associated inline scripts
 			$before_handle = $this->print_inline_script( $handle, 'before', false );
-			$after_handle = $this->print_inline_script( $handle, 'after', false );
-			if ( $before_handle || $after_handle )
+			$after_handle  = $this->print_inline_script( $handle, 'after', false );
+			if ( $before_handle || $after_handle ) {
 				$do_concat = false;
+			}
 
 			if ( true === $do_concat ) {
 				if ( !isset( $javascripts[$level] ) )

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -84,6 +84,12 @@ class WPcom_JS_Concat extends WP_Scripts {
 			else
 				$js_url['path'] = substr( $js_realpath, strlen( ABSPATH ) - 1 );
 
+			//Don't concat items with associated inline scripts
+			$before_handle = $this->print_inline_script( $handle, 'before', false );
+			$after_handle = $this->print_inline_script( $handle, 'after', false );
+			if ( $before_handle || $after_handle )
+				$do_concat = false;
+
 			if ( true === $do_concat ) {
 				if ( !isset( $javascripts[$level] ) )
 					$javascripts[$level]['type'] = 'concat';


### PR DESCRIPTION
The core skips concatenation of such files as well

See https://core.trac.wordpress.org/browser/trunk/src/wp-includes/class.wp-scripts.php#L298

Fixes #12 