### PR TITLE
Allow filtering of JS handles, similar CSS handles

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -91,6 +91,9 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$do_concat = false;
 			}
 
+			// Allow plugins to disable concatenation of certain scripts.
+			$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );
+
 			if ( true === $do_concat ) {
 				if ( !isset( $javascripts[$level] ) )
 					$javascripts[$level]['type'] = 'concat';


### PR DESCRIPTION
Right now there's not a way to opt a JS file out of concatenation, but there is for CSS.  This filter will allow plugins/themes to disable concatenation for a specific script/scripts if needed.