### PR TITLE
Bringing the no of args passed by style_loader_tag filter on par with core

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -129,7 +129,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 					$href = $this->cache_bust_mtime( $siteurl . current( $css ) );
 				}
 
-				echo apply_filters( 'style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handle );
+				echo apply_filters( 'style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handle, $href, $media );
 				array_map( array( $this, 'print_inline_style' ), array_keys( $css ) );
 			}
 		}


### PR DESCRIPTION
Since the WordPress core is passing 4 args, we should be doing the same when using the same filter in the mu-plugin.

This commit is adding $href and $media args.

Compare with https://github.com/WordPress/WordPress/blob/9cb5247392f376ab4b88ea13afd7d1ac8214afb4/wp-includes/class.wp-styles.php#L203 for reference