### PR TITLE
Removing call to parent class constructor from WPcom_JS_Concat's one

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -31,8 +31,6 @@ class WPcom_CSS_Concat extends WP_Styles {
 			}
 			unset( $this->$key );
 		}
-
-		parent::__construct();
 	}
 
 	function do_items( $handles = false, $group = false ) {

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -31,8 +31,6 @@ class WPcom_JS_Concat extends WP_Scripts {
 			}
 			unset( $this->$key );
 		}
-
-		parent::__construct();
 	}
 
 	function do_items( $handles = false, $group = false ) {


### PR DESCRIPTION
Since the `WP_Scripts::__construct` has either already been called outside the WPcom_JS_Concat class or is called from within the `WPcom_JS_Concat::__construct` during the initialisation of the `old_scripts` variable, we should not call the parent class consturctor again, as [it fires](https://github.com/WordPress/WordPress/blob/master/wp-includes/class.wp-scripts.php#L143) the `wp_default_scripts` action again.

The `wp_default_scripts` action is designed for 2 runs, before and after the `init` action. [If it's run after the `init` action, localisations are being populated](https://github.com/WordPress/WordPress/blob/493f76a3d2ef8c030ab5dcd4333f9a401208f534/wp-includes/script-loader.php#L89) and calling that action for the second time after the `init` action leads to doubling the localisation strings.