### PR TITLE
Ignore URLs that start with a hash (i.e. #)

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -149,7 +149,7 @@ foreach ( $args as $uri ) {
 
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 		$buf = preg_replace(
-			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:).)*)[\'"\s]*\)/isU',
+			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#).)*)[\'"\s]*\)/isU',
 			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
 			$buf
 		);


### PR DESCRIPTION
We don't want to append the full path to those urls as they are usually internal references (primarily in svgs).

Previously, `url(#a)` would get turned into `url(/absolute/path/#b)` which would break things. This retains the url as-is.