### PR TITLE
CSS: Don't append path to URLs that start with %23

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -149,7 +149,7 @@ foreach ( $args as $uri ) {
 
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 		$buf = preg_replace(
-			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#).)*)[\'"\s]*\)/isU',
+			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#|%23).)*)[\'"\s]*\)/isU',
 			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
 			$buf
 		);


### PR DESCRIPTION
Which is an encoded `#` and often used with svg data uris.

Continued from #25 