### PR TITLE
Support for subdirectory multisites

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,39 @@
+language: php
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+php:
+  - 5.3
+  - 5.6
+
+env:
+  - WP_VERSION=latest WP_MULTISITE=0
+
+matrix:
+  include:
+    - php: 5.3
+      env: WP_VERSION=latest WP_MULTISITE=1
+
+before_script:
+  - bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.0" ]]; then
+      composer global require "phpunit/phpunit=5.6.*"
+    else
+      composer global require "phpunit/phpunit=4.8.*"
+    fi
+  - |
+    composer global require wp-coding-standards/wpcs
+    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
+
+script:
+  - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
+  - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,6 @@ before_script:
     else
       composer global require "phpunit/phpunit=4.8.*"
     fi
-  - |
-    composer global require wp-coding-standards/wpcs
-    phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
 
 script:
   - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,5 +32,4 @@ before_script:
     fi
 
 script:
-  - phpcs --standard=phpcs.ruleset.xml $(find . -name '*.php')
   - phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,15 +10,15 @@ branches:
     - master
 
 php:
-  - 5.3
   - 5.6
+  - 7.0
 
 env:
   - WP_VERSION=latest WP_MULTISITE=0
 
 matrix:
   include:
-    - php: 5.3
+    - php: 7.0
       env: WP_VERSION=latest WP_MULTISITE=1
 
 before_script:

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,127 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version] [skip-database-creation]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+SKIP_DB_CREATE=${6-false}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/data/ $WP_TESTS_DIR/data
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		# remove all forward slashes in the end
+		WP_CORE_DIR=$(echo $WP_CORE_DIR | sed "s:/\+$::")
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR/':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+
+	if [ ${SKIP_DB_CREATE} = "true" ]; then
+		return 0
+	fi
+
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -19,4 +19,19 @@ class WPCOM_Concat_Utils {
 
 		return true;
 	}
+	public static function realpath( $url ) {
+		$url_parsed = parse_url( $url );
+		if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) ) {
+			$blog_details = get_blog_details();
+			if ( '/' !== $blog_details->path ) {
+				//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
+				$realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $url_parsed['path'] ) );
+			} else {
+				$realpath = realpath( ABSPATH . $url_parsed['path'] );
+			}
+		} else {
+			$realpath = realpath( ABSPATH . $url_parsed['path'] );
+		}
+		return $realpath;
+	}
 }

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -1,0 +1,20 @@
+<?php
+
+class WPCOM_Concat_Utils {
+	public static function is_internal_url( $test_url, $site_url ) {
+		$test_url_parsed = parse_url( $test_url );
+		$site_url_parsed = parse_url( $site_url );
+
+		if ( isset( $test_url_parsed['host'] )
+			&& $test_url_parsed['host'] !== $site_url_parsed['host'] ) {
+			return false;
+		}
+
+		if ( isset( $site_url_parsed['path'] )
+			&& 0 !== strpos( $test_url_parsed['path'], $site_url_parsed['path'] ) ) {
+			return false;
+		}	
+
+		return true;
+	}
+}

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -11,7 +11,9 @@ class WPCOM_Concat_Utils {
 		}
 
 		if ( isset( $site_url_parsed['path'] )
-			&& 0 !== strpos( $test_url_parsed['path'], $site_url_parsed['path'] ) ) {
+			&& 0 !== strpos( $test_url_parsed['path'], $site_url_parsed['path'] )
+			&& isset( $test_url_parsed['host'] ) //and if the URL of enqueued style is not relative
+		) {
 			return false;
 		}	
 

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -81,17 +81,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) ) {
-				$blog_details = get_blog_details();
-				if ( '/' !== $blog_details->path ) {
-					//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
-					$css_realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $css_url_parsed['path'] ) );
-				} else {
-					$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
-				}
-			} else {
-				$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
-			}
+			$css_realpath = WPCOM_Concat_Utils::realpath( $css_url );
 			if ( ! $css_realpath || 0 !== strpos( $css_realpath, ABSPATH ) )
 				$do_concat = false;
 			else

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -8,6 +8,8 @@ Version: 0.01
 Author URI: http://automattic.com/
  */
 
+require_once( dirname( __FILE__ ) . '/concat-utils.php' );
+
 if ( ! defined( 'ALLOW_GZIP_COMPRESSION' ) )
 	define( 'ALLOW_GZIP_COMPRESSION', true );
 
@@ -72,8 +74,10 @@ class WPcom_CSS_Concat extends WP_Styles {
 				$do_concat = false;
 
 			// Don't try to concat externally hosted scripts
-			if ( ( isset( $css_url_parsed['host'] ) && ( preg_replace( '/https?:\/\//', '', $siteurl ) != $css_url_parsed['host'] ) ) )
+			$is_internal_url = WPCOM_Concat_Utils::is_internal_url( $css_url, $siteurl );
+			if ( ! $is_internal_url ) {
 				$do_concat = false;
+			}
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -81,10 +81,14 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			$blog_details = get_blog_details();
-			if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) && '/' !== $blog_details->path ) {
-				//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
-				$css_realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $css_url_parsed['path'] ) );
+			if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) ) {
+				$blog_details = get_blog_details();
+				if ( '/' !== $blog_details->path ) {
+					//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
+					$css_realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $css_url_parsed['path'] ) );
+				} else {
+					$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
+				}
 			} else {
 				$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
 			}

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -48,18 +48,19 @@ class WPcom_CSS_Concat extends WP_Styles {
 			// Core is kind of broken and returns "true" for src of "colors" handle
 			// http://core.trac.wordpress.org/attachment/ticket/16827/colors-hacked-fixed.diff
 			// http://core.trac.wordpress.org/ticket/20729
-			if ( 'colors' == $obj->handle && true === $obj->src ) {
-				$css_url = parse_url( wp_style_loader_src( $obj->src, $obj->handle ) );
-			} else {
-				$css_url = parse_url( $obj->src );
+			$css_url = $obj->src;
+			if ( 'colors' == $obj->handle && true === $css_url ) {
+				$css_url = wp_style_loader_src( $css_url, $obj->handle );
 			}
+
+			$css_url_parsed = parse_url( $obj->src );
 			$extra = $obj->extra;
 
 			// Don't concat by default
 			$do_concat = false;
 
 			// Only try to concat static css files
-			if ( false !== strpos( $css_url['path'], '.css' ) )
+			if ( false !== strpos( $css_url_parsed['path'], '.css' ) )
 				$do_concat = true;
 
 			// Don't try to concat styles which are loaded conditionally (like IE stuff)
@@ -71,16 +72,16 @@ class WPcom_CSS_Concat extends WP_Styles {
 				$do_concat = false;
 
 			// Don't try to concat externally hosted scripts
-			if ( ( isset( $css_url['host'] ) && ( preg_replace( '/https?:\/\//', '', $siteurl ) != $css_url['host'] ) ) )
+			if ( ( isset( $css_url_parsed['host'] ) && ( preg_replace( '/https?:\/\//', '', $siteurl ) != $css_url_parsed['host'] ) ) )
 				$do_concat = false;
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			$css_realpath = realpath( ABSPATH . $css_url['path'] );
+			$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
 			if ( ! $css_realpath || 0 !== strpos( $css_realpath, ABSPATH ) )
 				$do_concat = false;
 			else
-				$css_url['path'] = substr( $css_realpath, strlen( ABSPATH ) - 1 );
+				$css_url_parsed['path'] = substr( $css_realpath, strlen( ABSPATH ) - 1 );
 
 			// Allow plugins to disable concatenation of certain stylesheets.
 			$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
@@ -92,7 +93,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 				if ( ! isset( $stylesheets[ $stylesheet_group_index ] ) || ( isset( $stylesheets[ $stylesheet_group_index ] ) && ! is_array( $stylesheets[ $stylesheet_group_index ] ) ) )
 					$stylesheets[ $stylesheet_group_index ] = array();
 
-				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url['path'];
+				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url_parsed['path'];
 				$this->done[] = $handle;
 			} else {
 				$stylesheet_group_index++;

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -147,7 +147,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
 			return $url;
 
-		$file = ABSPATH . ltrim( $parts['path'], '/' );
+		$file = WPCOM_Concat_Utils::realpath( $url );
 
 		$mtime = false;
 		if ( file_exists( $file ) )

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -81,7 +81,13 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
+			$blog_details = get_blog_details();
+			if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) && '/' !== $blog_details->path ) {
+				//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
+				$css_realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $css_url_parsed['path'] ) );
+			} else {
+				$css_realpath = realpath( ABSPATH . $css_url_parsed['path'] );
+			}
 			if ( ! $css_realpath || 0 !== strpos( $css_realpath, ABSPATH ) )
 				$do_concat = false;
 			else

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -132,7 +132,8 @@ class WPcom_CSS_Concat extends WP_Styles {
 					$href = $this->cache_bust_mtime( $siteurl . current( $css ) );
 				}
 
-				echo apply_filters( 'style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handle, $href, $media );
+				$handles = array_keys( $css );
+				echo apply_filters( 'ngx_http_concat_style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handles, $href, $media );
 				array_map( array( $this, 'print_inline_style' ), array_keys( $css ) );
 			}
 		}

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -81,7 +81,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			$css_realpath = WPCOM_Concat_Utils::realpath( $css_url );
+			$css_realpath = WPCOM_Concat_Utils::realpath( $css_url, $siteurl );
 			if ( ! $css_realpath || 0 !== strpos( $css_realpath, ABSPATH ) )
 				$do_concat = false;
 			else
@@ -129,7 +129,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 					$href = $siteurl . "/_static/??" . $path_str;
 				} else {
-					$href = $this->cache_bust_mtime( $siteurl . current( $css ) );
+					$href = $this->cache_bust_mtime( $siteurl . current( $css ), $siteurl );
 				}
 
 				$handles = array_keys( $css );
@@ -140,7 +140,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 		return $this->done;
 	}
 
-	function cache_bust_mtime( $url ) {
+	function cache_bust_mtime( $url, $siteurl ) {
 		if ( strpos( $url, '?m=' ) )
 			return $url;
 
@@ -148,7 +148,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
 			return $url;
 
-		$file = WPCOM_Concat_Utils::realpath( $url );
+		$file = WPCOM_Concat_Utils::realpath( $url, $siteurl );
 
 		$mtime = false;
 		if ( file_exists( $file ) )

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -62,7 +62,8 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$this->in_footer = array_diff( $this->in_footer, (array) $handle );
 
 			$obj = $this->registered[$handle];
-			$js_url_parsed = parse_url( $obj->src );
+			$js_url = $obj->src;
+			$js_url_parsed = parse_url( $js_url );
 			$extra = $obj->extra;
 
 			// Check for scripts added from wp_add_inline_script()

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -91,7 +91,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			$js_realpath = WPCOM_Concat_Utils::realpath( $js_url );
+			$js_realpath = WPCOM_Concat_Utils::realpath( $js_url, $siteurl );
 			if ( ! $js_realpath || 0 !== strpos( $js_realpath, ABSPATH ) )
 				$do_concat = false;
 			else
@@ -147,7 +147,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 
 					$href = $siteurl . "/_static/??" . $path_str;
 				} else {
-					$href = $this->cache_bust_mtime( $siteurl . $js_array['paths'][0] );
+					$href = $this->cache_bust_mtime( $siteurl . $js_array['paths'][0], $siteurl );
 				}
 
 				$this->done = array_merge( $this->done, $js_array['handles'] );
@@ -170,7 +170,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 		return $this->done;
 	}
 
-	function cache_bust_mtime( $url ) {
+	function cache_bust_mtime( $url, $siteurl ) {
 		if ( strpos( $url, '?m=' ) )
 			return $url;
 
@@ -178,7 +178,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
 			return $url;
 
-		$file = WPCOM_Concat_Utils::realpath( $url );
+		$file = WPCOM_Concat_Utils::realpath( $url, $siteurl );
 
 		$mtime = false;
 		if ( file_exists( $file ) )

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -178,7 +178,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 		if ( ! isset( $parts['path'] ) || empty( $parts['path'] ) )
 			return $url;
 
-		$file = ABSPATH . ltrim( $parts['path'], '/' );
+		$file = WPCOM_Concat_Utils::realpath( $url );
 
 		$mtime = false;
 		if ( file_exists( $file ) )

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -90,17 +90,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 
 			// Concat and canonicalize the paths only for
 			// existing scripts that aren't outside ABSPATH
-			if ( true === is_multisite() && false == constant( 'SUBDOMAIN_INSTALL' ) ) {
-				$blog_details = get_blog_details();
-				if ( '/' !== $blog_details->path ) {
-					//In case of subdir multisite, we need to remove the blog's path from the style's path in order to be able to find the file
-					$js_realpath = realpath( ABSPATH . str_replace( $blog_details->path, '', $js_url_parsed['path'] ) );
-				} else {
-					$js_realpath = realpath( ABSPATH . $js_url_parsed['path'] );
-				}
-			} else {
-				$js_realpath = realpath( ABSPATH . $js_url_parsed['path'] );
-			}
+			$js_realpath = WPCOM_Concat_Utils::realpath( $js_url );
 			if ( ! $js_realpath || 0 !== strpos( $js_realpath, ABSPATH ) )
 				$do_concat = false;
 			else

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,14 @@
+<phpunit
+	bootstrap="tests/bootstrap.php"
+	backupGlobals="false"
+	colors="true"
+	convertErrorsToExceptions="true"
+	convertNoticesToExceptions="true"
+	convertWarningsToExceptions="true"
+	>
+	<testsuites>
+		<testsuite>
+			<directory prefix="test-" suffix=".php">./tests/</directory>
+		</testsuite>
+	</testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * PHPUnit bootstrap file
+ *
+ * @package Http_Concat
+ */
+
+$_tests_dir = getenv( 'WP_TESTS_DIR' );
+if ( ! $_tests_dir ) {
+	$_tests_dir = '/tmp/wordpress-tests-lib';
+}
+
+// Give access to tests_add_filter() function.
+require_once $_tests_dir . '/includes/functions.php';
+
+/**
+ * Manually load the plugin being tested.
+ */
+function _manually_load_plugin() {
+	require dirname( dirname( __FILE__ ) ) . '/cssconcat.php';
+	require dirname( dirname( __FILE__ ) ) . '/jsconcat.php';
+}
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+// Start up the WP testing environment.
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-concat-utils.php
+++ b/tests/test-concat-utils.php
@@ -1,0 +1,68 @@
+<?php
+
+class WPCOM_Concat_Utils__Is_External_Url__TestCase extends WP_UnitTestCase {
+	function get_test_data() {
+		return array(
+			// External
+			'single_site__external_url' => array(
+				'https://fonts.googleapis.com/path/to/file.css',
+				'https://example.com',
+				false,
+			),
+			
+			'subdir_site__external_url' => array(
+				'https://fonts.googleapis.com/path/to/file.css',
+				'https://example.com/mysite',
+				false,
+			),
+
+			// Interal: Full URL
+			'single_site__internal_url' => array(
+				'https://example.com/wp-content/plugins/plugin/style.css',
+				'https://example.com',
+				true,
+			),
+
+			'single_site_trailingslash__internal_url' => array(
+				'https://example.com/wp-content/plugins/plugin/style.css',
+				'https://example.com/',
+				true,
+			),
+
+
+			'subdir_site__internal_subdir_url' => array(
+				'https://example.com/mysite/wp-content/plugins/plugin/style.css',
+				'https://example.com/mysite',
+				true,
+			),
+
+			'subdir_site__internal_root_url' => array(
+				'https://example.com/wp-content/plugins/plugin/style.css',
+				'https://example.com/mysite',
+				false,
+			),
+
+			// Internal: absolute (i.e. no host, /wp-content/path/to/file.css)
+			'single_site__internal_absolute_url' => array(
+				'/wp-content/plugins/plugin/style.css',
+				'https://example.com',
+				true,
+			),
+
+			'subdir_site__internal_absolute_url' => array(
+				'/wp-content/plugins/plugin/style.css',
+				'https://example.com/mysite',
+				false,
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_test_data
+	 */
+	function test__function( $test_url, $site_url, $expected ) {
+		$actual = WPCOM_Concat_Utils::is_internal_url( $test_url, $site_url );
+
+		$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/test-concat-utils.php
+++ b/tests/test-concat-utils.php
@@ -52,7 +52,7 @@ class WPCOM_Concat_Utils__Is_External_Url__TestCase extends WP_UnitTestCase {
 			'subdir_site__internal_absolute_url' => array(
 				'/wp-content/plugins/plugin/style.css',
 				'https://example.com/mysite',
-				false,
+				true,
 			),
 		);
 	}


### PR DESCRIPTION
Properly handle subdirectory sites on a multisite install. The original code for this plugin was written for WordPress.com which only supports domains and has many related assumptions that fail when running in a subdirectory (either as part of a multisite or on its own).