### PR TITLE
Adjusting Style Loader Tag Filter

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -127,7 +127,8 @@ class WPcom_CSS_Concat extends WP_Styles {
 					$href = $this->cache_bust_mtime( $siteurl . current( $css ) );
 				}
 
-				echo apply_filters( 'style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handle, $href, $media );
+				$handles = array_keys( $css );
+				echo apply_filters( 'concat_style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handles, $href, $media );
 				array_map( array( $this, 'print_inline_style' ), array_keys( $css ) );
 			}
 		}

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -128,7 +128,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 				}
 
 				$handles = array_keys( $css );
-				echo apply_filters( 'concat_style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handles, $href, $media );
+				echo apply_filters( 'ngx_http_concat_style_loader_tag', "<link rel='stylesheet' id='$media-css-$idx' href='$href' type='text/css' media='$media' />\n", $handles, $href, $media );
 				array_map( array( $this, 'print_inline_style' ), array_keys( $css ) );
 			}
 		}


### PR DESCRIPTION
Since the original `style_loader_tag` filters against a _single_ handle, this can cause problems when the concatenated file contains multiple handles worth of CSS.

This produced a bug where the `Jetpack::concat_remove_style_loader_tag()` filter would remove an _entire_ concatenated file's worth of CSS just because it contained one handle.

The new filter will allow the concatenated tag to still be adjusted if necessary, but it's not at the mercy of one handle removing all of the file.