### PR TITLE
Fix/ignore urls starting with hash

### DIFF
--- a/concat-utils.php
+++ b/concat-utils.php
@@ -37,4 +37,15 @@ class WPCOM_Concat_Utils {
 
 		return realpath( ABSPATH . $url_path );
 	}
+
+	public static function relative_path_replace( $buf, $dirpath ) {
+		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
+		$buf = preg_replace(
+			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#|%23).)*)[\'"\s]*\)/isU',
+			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
+			$buf
+		);
+
+		return $buf;
+	}
 }

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -41,7 +41,7 @@ class WPCOM_Concat_Utils {
 	public static function relative_path_replace( $buf, $dirpath ) {
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 		$buf = preg_replace(
-			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#|%23).)*)[\'"\s]*\)/isU',
+			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|[\(\'"]#|%23).)*)[\'"\s]*\)/isU',
 			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
 			$buf
 		);

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -12,6 +12,7 @@
  */
 
 require __DIR__ . '/cssmin.php';
+require_once( dirname(__FILE__) . '/concat-utils.php' );
 
 /* Config */
 $concat_max_files = 150;
@@ -148,11 +149,7 @@ foreach ( $args as $uri ) {
 		$dirpath = dirname( $uri );
 
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
-		$buf = preg_replace(
-			'/(:?\s*url\s*\()\s*(?:\'|")?\s*([^\/\'"\s\)](?:(?<!data:|http:|https:|#|%23).)*)[\'"\s]*\)/isU',
-			'$1' . ( $dirpath == '/' ? '/' : $dirpath . '/' ) . '$2)',
-			$buf
-		);
+		$buf = WPCOM_Concat_Utils::relative_path_replace( $buf, $dirpath );
 
 		// AlphaImageLoader(...src='relative/path/to/file'...) -> AlphaImageLoader(...src='/absolute/path/to/file'...)
 		$buf = preg_replace(

--- a/tests/test-concat-utils.php
+++ b/tests/test-concat-utils.php
@@ -66,3 +66,144 @@ class WPCOM_Concat_Utils__Is_External_Url__TestCase extends WP_UnitTestCase {
 		$this->assertSame( $expected, $actual );
 	}
 }
+
+class WPCOM_Concat_Utils__Replace_Relative_Url__TestCase extends WP_UnitTestCase {
+	function get_test_data() {
+		return array(
+			// Relative URL with double quotes.
+			'relative_url_double_quotes' => array(
+				'src:url("social-logos.eot?51b607ee5b5cb2a0e4517176475a424c");',
+				'src:url(/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+			),
+			// Relative URL with double quotes subdir.
+			'relative_url_double_quotes_subdir' => array(
+				'src:url("social-logos.eot?51b607ee5b5cb2a0e4517176475a424c");',
+				'src:url(/mysite/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+				'/mysite',
+			),
+			// Relative URL with single quotes.
+			'relative_url_single_quotes' => array(
+				'src:url(\'social-logos.eot?51b607ee5b5cb2a0e4517176475a424c\');',
+				'src:url(/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);'
+			),
+			// Relative URL with single quotes subdir.
+			'relative_url_single_quotes_subdir' => array(
+				'src:url(\'social-logos.eot?51b607ee5b5cb2a0e4517176475a424c\');',
+				'src:url(/mysite/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+				'/mysite',
+			),
+			// Relative URL no quotation marks.
+			'relative_url_no_quotes' => array(
+				'src:url(social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+				'src:url(/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+			),
+			// Relative URL no quotation marks subdir.
+			'relative_url_no_quotes_subdir' => array(
+				'src:url(social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+				'src:url(/mysite/social-logos.eot?51b607ee5b5cb2a0e4517176475a424c);',
+				'/mysite',
+			),
+			// Absolute URL double quotes.
+			'absolute_url_double_quotes' => array(
+				'src:url("https://fonts.googleapis.com/path/to/file.css");',
+				'src:url("https://fonts.googleapis.com/path/to/file.css");',
+			),
+			// Absolute URL single quotes.
+			'absolute_url_single_quotes' => array(
+				'src:url(\'https://fonts.googleapis.com/path/to/file.css\');',
+				'src:url(\'https://fonts.googleapis.com/path/to/file.css\');',
+			),
+			// Absolute URL no quotes.
+			'absolute_url_no_quotes' => array(
+				'src:url(https://fonts.googleapis.com/path/to/file.css);',
+				'src:url(https://fonts.googleapis.com/path/to/file.css);',
+			),
+			// Relative URL containing hashtag in double quotes.
+			'relative_url_with_hashtag_double_quotes' => array(
+				'src:url("social-logos.eot?#iefix");',
+				'src:url(/social-logos.eot?#iefix);',
+			),
+			// Relative URL containing hashtag in double quotes subdir.
+			'relative_url_with_hashtag_double_quotes_subdir' => array(
+				'src:url("social-logos.eot?#iefix");',
+				'src:url(/mysite/social-logos.eot?#iefix);',
+				'/mysite',
+			),
+			// Relative URL contaiing hashtag in single quotes.
+			'relative_url_with_hashtag_single_quotes' => array(
+				'src:url(\'social-logos.eot?#iefix\');',
+				'src:url(/social-logos.eot?#iefix);',
+			),
+			// Relative URL contaiing hashtag in single quotes subdir.
+			'relative_url_with_hashtag_single_quotes_subdir' => array(
+				'src:url(\'social-logos.eot?#iefix\');',
+				'src:url(/mysite/social-logos.eot?#iefix);',
+				'/mysite',
+			),
+			// Relative URL containig hashtag w/o quotes.
+			'relative_url_with_hashtag_no_quotes' => array(
+				'src:url(social-logos.eot?#iefix);',
+				'src:url(/social-logos.eot?#iefix);',
+			),
+			// Relative URL containig hashtag w/o quotes subdir.
+			'relative_url_with_hashtag_no_quotes_subdir' => array(
+				'src:url(social-logos.eot?#iefix);',
+				'src:url(/mysite/social-logos.eot?#iefix);',
+				'/mysite',
+			),
+			// Relative URL starting with hashtag double quotes.
+			'relative_url_starting_with_hashtag_double_quotes' => array(
+				'src:url("#social-logos.eot")',
+				'src:url("#social-logos.eot")',
+			),
+			// Relative URL starting with hashtag single quotes.
+			'relative_url_starting_with_hashtag_single_quotes' => array(
+				'src:url(\'#social-logos.eot\')',
+				'src:url(\'#social-logos.eot\')',
+			),
+			// Relative URL starting with hashtag no quotes.
+			'relative_url_starting_with_hashtag_no_quotes' => array(
+				'src:url(#social-logos.eot)',
+				'src:url(#social-logos.eot)',
+			),
+			// data: URL double quotes.
+			'data_url_double_quotes' => array(
+				'src:url(url("data:application/x-font-woff;charset=utf-8;base64,d09GRk9UVE8AAEZAAAoAAAAAfBAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAQsUAAHZfa1y5A0ZGVE0AAEO8AAAAGQAAABx4Dt9ZT1MvMgAAQ9gAAABKAAAAYEC7Yj5jbWFwAABEJAAAAIUAAAG6pEWcoGhlYWQAAESsAAAALwAAADYHEbeJaGhlYQAARNwAAAAdAAAAJAOvAd5obXR4AABE/AAAADgAAABeCDEE521heHAAAEU0AAAABgAAAAYALVAAbmFtZQAARTwAAADrAAAB5koHYmpwb3N0AABGKAAAABYAAAAg/8MAGnicrZ13mJXFFfDn3XbvVnb37i596SC9d8uLDQyKFXtD7F0RYzSGay9LDCpqjB1REaPR2CXCFbGB2ACR3otLWdje5zu/M++9QGK+fH98Dzyz804vZ86cOtczKSnG87zsKTdMvmrStX2vveGKG6YYL8l45qTaFqZ2rFc7Lqn2hOTaVinTs7zibW36ZyUXd3vVZqUUZ5jWp+fbkpJEJCv04mW102p7pbZLat2inTG57ZJuzmtn+rSb2jLf9KfJsGlhikx709X0NoPMSOObsWaCmWjON5PN1eYmc5uZZu43fzYzzTNmlnndvG0+NPPNF+Zbs8ysNpvMTlNmqk2Tl+Jlevlea6+j18Pr5w2Vf2O8k6Zef9XxAwcM5M+gAQPcn+BrkPsz2P0Z6v4Mc3+Guz8j9c9AV2+gqzf")',
+				'src:url(url("data:application/x-font-woff;charset=utf-8;base64,d09GRk9UVE8AAEZAAAoAAAAAfBAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAQsUAAHZfa1y5A0ZGVE0AAEO8AAAAGQAAABx4Dt9ZT1MvMgAAQ9gAAABKAAAAYEC7Yj5jbWFwAABEJAAAAIUAAAG6pEWcoGhlYWQAAESsAAAALwAAADYHEbeJaGhlYQAARNwAAAAdAAAAJAOvAd5obXR4AABE/AAAADgAAABeCDEE521heHAAAEU0AAAABgAAAAYALVAAbmFtZQAARTwAAADrAAAB5koHYmpwb3N0AABGKAAAABYAAAAg/8MAGnicrZ13mJXFFfDn3XbvVnb37i596SC9d8uLDQyKFXtD7F0RYzSGay9LDCpqjB1REaPR2CXCFbGB2ACR3otLWdje5zu/M++9QGK+fH98Dzyz804vZ86cOtczKSnG87zsKTdMvmrStX2vveGKG6YYL8l45qTaFqZ2rFc7Lqn2hOTaVinTs7zibW36ZyUXd3vVZqUUZ5jWp+fbkpJEJCv04mW102p7pbZLat2inTG57ZJuzmtn+rSb2jLf9KfJsGlhikx709X0NoPMSOObsWaCmWjON5PN1eYmc5uZZu43fzYzzTNmlnndvG0+NPPNF+Zbs8ysNpvMTlNmqk2Tl+Jlevlea6+j18Pr5w2Vf2O8k6Zef9XxAwcM5M+gAQPcn+BrkPsz2P0Z6v4Mc3+Guz8j9c9AV2+gqzf")',
+			),
+			'data_url_single_quotes' => array(
+				'src:url(url(\'data:application/x-font-woff;charset=utf-8;base64,d09GRk9UVE8AAEZAAAoAAAAAfBAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAQsUAAHZfa1y5A0ZGVE0AAEO8AAAAGQAAABx4Dt9ZT1MvMgAAQ9gAAABKAAAAYEC7Yj5jbWFwAABEJAAAAIUAAAG6pEWcoGhlYWQAAESsAAAALwAAADYHEbeJaGhlYQAARNwAAAAdAAAAJAOvAd5obXR4AABE/AAAADgAAABeCDEE521heHAAAEU0AAAABgAAAAYALVAAbmFtZQAARTwAAADrAAAB5koHYmpwb3N0AABGKAAAABYAAAAg/8MAGnicrZ13mJXFFfDn3XbvVnb37i596SC9d8uLDQyKFXtD7F0RYzSGay9LDCpqjB1REaPR2CXCFbGB2ACR3otLWdje5zu/M++9QGK+fH98Dzyz804vZ86cOtczKSnG87zsKTdMvmrStX2vveGKG6YYL8l45qTaFqZ2rFc7Lqn2hOTaVinTs7zibW36ZyUXd3vVZqUUZ5jWp+fbkpJEJCv04mW102p7pbZLat2inTG57ZJuzmtn+rSb2jLf9KfJsGlhikx709X0NoPMSOObsWaCmWjON5PN1eYmc5uZZu43fzYzzTNmlnndvG0+NPPNF+Zbs8ysNpvMTlNmqk2Tl+Jlevlea6+j18Pr5w2Vf2O8k6Zef9XxAwcM5M+gAQPcn+BrkPsz2P0Z6v4Mc3+Guz8j9c9AV2+gqzf\')',
+				'src:url(url(\'data:application/x-font-woff;charset=utf-8;base64,d09GRk9UVE8AAEZAAAoAAAAAfBAAAQAAAAAAAAAAAAAAAAAAAAAAAAAAAABDRkYgAAAA9AAAQsUAAHZfa1y5A0ZGVE0AAEO8AAAAGQAAABx4Dt9ZT1MvMgAAQ9gAAABKAAAAYEC7Yj5jbWFwAABEJAAAAIUAAAG6pEWcoGhlYWQAAESsAAAALwAAADYHEbeJaGhlYQAARNwAAAAdAAAAJAOvAd5obXR4AABE/AAAADgAAABeCDEE521heHAAAEU0AAAABgAAAAYALVAAbmFtZQAARTwAAADrAAAB5koHYmpwb3N0AABGKAAAABYAAAAg/8MAGnicrZ13mJXFFfDn3XbvVnb37i596SC9d8uLDQyKFXtD7F0RYzSGay9LDCpqjB1REaPR2CXCFbGB2ACR3otLWdje5zu/M++9QGK+fH98Dzyz804vZ86cOtczKSnG87zsKTdMvmrStX2vveGKG6YYL8l45qTaFqZ2rFc7Lqn2hOTaVinTs7zibW36ZyUXd3vVZqUUZ5jWp+fbkpJEJCv04mW102p7pbZLat2inTG57ZJuzmtn+rSb2jLf9KfJsGlhikx709X0NoPMSOObsWaCmWjON5PN1eYmc5uZZu43fzYzzTNmlnndvG0+NPPNF+Zbs8ysNpvMTlNmqk2Tl+Jlevlea6+j18Pr5w2Vf2O8k6Zef9XxAwcM5M+gAQPcn+BrkPsz2P0Z6v4Mc3+Guz8j9c9AV2+gqzf\')',
+			),
+			// Absolute URL non-secure double quotes.
+			'absolute_url_http_double_quotes' => array(
+				'src:url("http://fonts.googleapis.com/path/to/file.css")',
+				'src:url("http://fonts.googleapis.com/path/to/file.css")',
+			),
+			// Absolute URL non-secure single quotes.
+			'absolute_url_http_single_quotes' => array(
+				'src:url(\'http://fonts.googleapis.com/path/to/file.css\')',
+				'src:url(\'http://fonts.googleapis.com/path/to/file.css\')',
+			),
+			// Absolute URL non-secure no quotes.
+			'absolute_url_http_no_quotes' => array(
+				'src:url(http://fonts.googleapis.com/path/to/file.css)',
+				'src:url(http://fonts.googleapis.com/path/to/file.css)',
+			),
+			// Absolute URL containing hashtag
+			'absolute_url_containig_hashtag' => array(
+				'src:url(http://fonts.googleapis.com/path/to/file.css#iefix)',
+				'src:url(http://fonts.googleapis.com/path/to/file.css#iefix)',
+			),
+		);
+	}
+
+	/**
+	 * @dataProvider get_test_data
+	 */
+	function test__function( $test_string, $expected, $dirpath = '/' ) {
+		$actual = WPCOM_Concat_Utils::relative_path_replace( $test_string, $dirpath );
+		//if ( false === strpos( $test_string, '?#' ) )
+			$this->assertSame( $expected, $actual );
+	}
+}

--- a/tests/test-concat-utils.php
+++ b/tests/test-concat-utils.php
@@ -203,7 +203,6 @@ class WPCOM_Concat_Utils__Replace_Relative_Url__TestCase extends WP_UnitTestCase
 	 */
 	function test__function( $test_string, $expected, $dirpath = '/' ) {
 		$actual = WPCOM_Concat_Utils::relative_path_replace( $test_string, $dirpath );
-		//if ( false === strpos( $test_string, '?#' ) )
-			$this->assertSame( $expected, $actual );
+		$this->assertSame( $expected, $actual );
 	}
 }


### PR DESCRIPTION
This PR moves the direct `preg_replace` call for replacing relative CSS paths to absolute ones into a testable class method, adds tests for the functionality and fixes an issue introduced in 2e29e538c7a0fb9ad73f68814e992fc5d611eef1 which is not only catching URLs starting with a hash, but also any URLs containing a hash, which should be otherwise transformed to absolute ones - eg.: Jetpack's `social-logos.eot?#iefix`.