### PR TITLE
Suppressing warnings for gzuncompress

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -99,7 +99,7 @@ if ( '-' == $args[0] ) {
 
 	// Invalid data, abort!
 	if ( false === $args ) {
-		die();
+		concat_http_status_exit( 400 );
 	}
 }
 

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -95,7 +95,7 @@ $args = substr( $args, strpos( $args, '?' ) + 1 );
 // or
 // -eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
 if ( '-' == $args[0] )
-	$args = gzuncompress( base64_decode( substr( $args, 1 ) ) );
+	$args = @gzuncompress( base64_decode( substr( $args, 1 ) ) );
 
 // /foo/bar.css,/foo1/bar/baz.css?m=293847g
 $version_string_pos = strpos( $args, '?' );

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -94,8 +94,14 @@ $args = substr( $args, strpos( $args, '?' ) + 1 );
 // /foo/bar.css,/foo1/bar/baz.css?m=293847g
 // or
 // -eJzTT8vP109KLNJLLi7W0QdyDEE8IK4CiVjn2hpZGluYmKcDABRMDPM=
-if ( '-' == $args[0] )
+if ( '-' == $args[0] ) {
 	$args = @gzuncompress( base64_decode( substr( $args, 1 ) ) );
+
+	// Invalid data, abort!
+	if ( false === $args ) {
+		die();
+	}
+}
 
 // /foo/bar.css,/foo1/bar/baz.css?m=293847g
 $version_string_pos = strpos( $args, '?' );


### PR DESCRIPTION
`gzuncompress()` will throw a warning with bad data, which can happen from malformed URIs.

p6jPRI-127-p2