### PR TITLE
Add async defer filter

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -160,7 +160,8 @@ class WPcom_JS_Concat extends WP_Scripts {
 				}
 				//Allow sites to async and defer the concatenated JS
 				$should_async = apply_filters( 'js_concat_should_async', false );
-				echo "<script type='text/javascript' src='$href' " . ( $should_async ? 'async defer' : '' ) . "></script>\n";
+				$should_defer = apply_filters( 'js_concat_should_defer', false );
+				echo "<script type='text/javascript' src='$href' " . ( $should_async ? 'async' : '' ) . ( $should_defer ? 'defer' : '' ) . " ></script>\n";
 				if ( isset( $js_array['extras']['after'] ) ) {
 					foreach ( $js_array['extras']['after'] as $inline_after ) {
 						echo $inline_after;

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -158,7 +158,9 @@ class WPcom_JS_Concat extends WP_Scripts {
 						echo $inline_before;
 					}
 				}
-				echo "<script type='text/javascript' src='$href'></script>\n";
+				//Allow sites to async and defer the concatenated JS
+				$should_async = apply_filters( 'js_concat_should_async', false );
+				echo "<script type='text/javascript' src='$href' " . ( $should_async ? 'async defer' : '' ) . "></script>\n";
 				if ( isset( $js_array['extras']['after'] ) ) {
 					foreach ( $js_array['extras']['after'] as $inline_after ) {
 						echo $inline_after;


### PR DESCRIPTION
Some sites might want to add async and defer to the concatenated javascript, this can now be turned on by returning true (or a truthy value) to the 'js_concat_should_async' filter