### PR TITLE
Allow CONCAT_FILES_ROOT to be set outside the plugin

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -25,7 +25,7 @@ $concat_types = array(
 
 /* Constants */
 // By default determine the document root from this scripts path in the plugins dir (you can hardcode this define)
-define( 'CONCAT_FILES_ROOT', substr( dirname( __DIR__ ), 0, strpos( dirname( __DIR__ ), '/wp-content' ) ) );
+defined( 'CONCAT_FILES_ROOT' ) || define( 'CONCAT_FILES_ROOT', substr( dirname( __DIR__ ), 0, strpos( dirname( __DIR__ ), '/wp-content' ) ) );
 
 function concat_http_status_exit( $status ) {
 	switch ( $status ) {


### PR DESCRIPTION
If CONCAT_FILES_ROOT is already set, use that instead of forcing it to be defined here.

In some instances, we may want to customize the location of core files.