### PR TITLE
Implement 'js_concat_script_attributes' to allow users to add extra tag attributes

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -158,7 +158,26 @@ class WPcom_JS_Concat extends WP_Scripts {
 						echo $inline_before;
 					}
 				}
-				echo "<script type='text/javascript' src='$href'></script>\n";
+
+				/**
+				 * Allow adding extra arguments for the script tag.
+				 * Either associative array or regular array.
+				 * E.g.
+				 * [ 'async', 'defer', 'onload' => 'onLoadCallback' ]
+				 *
+				 * @param string $href url for the script
+				 * @param array $js_array holds the additional information on handles being concatenated, their real path, urls, etc
+				 * @param WPcom_JS_Concat this instance of WPcom_JS_Concat
+				 */
+				$attr_string = '';
+				foreach ( (array) apply_filters( 'js_concat_script_attributes', [], $href, $js_array, $this ) as $k => $v ) {
+					if ( ! is_scalar( $v ) )
+						continue;
+
+					$attr_string .= sprintf( ' %s="%s"', sanitize_key( is_int( $k ) ? $v : $k ), esc_attr( $v ) );
+				}
+				printf( '<script type="text/javascript" src="%s" %s></script>', $href, $attr_string );
+
 				if ( isset( $js_array['extras']['after'] ) ) {
 					foreach ( $js_array['extras']['after'] as $inline_after ) {
 						echo $inline_after;


### PR DESCRIPTION
The filter gets passed an empty array and has to return an associative or regular array with attributes as keys, additional arguments for the filter are: $href - current batch url, $js_array - additional data for current batch of scripts.

This filter runs on each batch of files; extra arguments are needed to better control attributes being assigned to a resulting tag.

For example, we want to set async/defer for either a specific group of files being concatenated or maybe we want to do a blanket change for every resulting script tag.

A minimal example would be
```php
add_filter( 'js_concat_script_attributes', function( $attrs, $href, $js_array, $jsconcat ) {
	return stristr( $href, '_static' ) !== false ? [ 'async' => true, 'defer' ] : [];
}, 10, 4 );
```

Fixes #33, supersedes #36