### PR TITLE
Fix for issue #39 - Print extra JS data when handling a group with no src attribute.

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -48,6 +48,8 @@ class WPcom_JS_Concat extends WP_Scripts {
 				continue;
 
 			if ( ! $this->registered[$handle]->src ) { // Defines a group.
+				// if there are localized items, echo them
+				$this->print_extra_script( $handle );
 				$this->done[] = $handle;
 				continue;
 			}


### PR DESCRIPTION
Fixes #39

In the case of a registered handle with an empty src attribute, we still need to run print_extra_script in case there was localized data registered to the same handle (this usually happens in a different call).

The assumption was perhaps that this wouldn't be happening, but it happens with the WordPress core mediaelement handle.

To reproduce:
On any site using WordPress 4.9.6 and this plugin, embed a WordPress video. View source, and search for _wpmejsSettings - it won't be found. It'll be undefined in console. Apply this change, it should now be present. Depending on the video embedded, black bars will no longer appear.

Here's a public URL that currently has the issue (and a link that disables this plugin's JS concat and thus the issue does not happen). With this change, the issue should go away:
(with issue) https://grazia.com.au/articles/mbfwa-day-four-the-insiders-go-backstage-at-leo-and-lin/
(no concat, no issue) https://grazia.com.au/articles/mbfwa-day-four-the-insiders-go-backstage-at-leo-and-lin/?concat_js=no

**UPDATE** - this code below, added to functions.php or mu-plugins, will allow any site to verify this script
(use only for testing!)
```
function fubar_enqueue( &$scripts ) {
    $scripts->add( 'foobar', false, array( 'jquery' ), '123', true );
    $scripts->localize( 'foobar', '_fubar', array( 'foo' => 'bar' ) );
}   
add_action( 'wp_default_scripts', 'fubar_enqueue' );

function jsconcat_test_enqueue() {
      wp_enqueue_script( 'foobar' );
}
add_action( 'wp_enqueue_scripts', 'jsconcat_test_enqueue' );
```

**STEPS TO REPRODUCE THE ISSUE** (with above test code in place, without this patch)
1. Load any front end page for example the home page, and open the browser JS console
2. Type _fubar and hit enter. Verify that you see `Uncaught ReferenceError: _fubar is not defined`
3. Append ?concat_js=no to the same url, and load that
4. Again type _fubar and hit enter. You should see a JS object `{foo: "bar"}`
These steps verify that the concatenated code is omitting the _fubar definition

**STEPS TO VERIFY THE FIX** (with above test code in place, with this patch applied)
1. Load any front end page (append ?b=c to bust the cache), open the browser console
2. _fubar should return the JS object `{foo: "bar"}`
3. You should see the same result with JS Concat disabled (?concat_js=no) or with it enabled.

**RECOMMENDED REGRESSION TESTS**
1. Test your site (home, article pages) with JS concat disabled (?jconcat_js=no) and verify nothing "breaks"

The code change is additive. With the fix, an additional print_extra_script is called for the handle that previously was missing it. The most likely regression failure / issue is where someone manually defined the missing variable. In that case, depending on the code they wrote and where it was placed, there may be a JS conflict or the JS variable may have an unexpected value.

That **should** be apparent if the site is viewed with JS Concat disabled (no need for any code changes).

This should be easy to identify in the case of anyone using the same plugin as Grazia - "_wpmejsSettings" may show up in their codebase. It's likely there are other plugins that enqueue in a similar manner (a group with no src but with localized data), they may be difficult to identify.
