### PR TITLE
Exclude concatenation for js files which have inline js added

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -89,17 +89,17 @@ class WPcom_JS_Concat extends WP_Scripts {
 			else
 				$js_url_parsed['path'] = substr( $js_realpath, strlen( ABSPATH ) - 1 );
 
-            // Check for scripts added from wp_add_inline_script()
-            $before_handle = $this->print_inline_script( $handle, 'before', false );
-            $after_handle = $this->print_inline_script( $handle, 'after', false );
-            if ( $before_handle ) {
-                $do_concat = false;
-                $before_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $before_handle );
-            }
-            if ( $after_handle ) {
-                $after_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $after_handle );
-                $do_concat = false;
-            }
+			// Check for scripts added from wp_add_inline_script()
+			$before_handle = $this->print_inline_script( $handle, 'before', false );
+			$after_handle = $this->print_inline_script( $handle, 'after', false );
+			if ( $before_handle ) {
+				$do_concat = false;
+				$before_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $before_handle );
+			}
+			if ( $after_handle ) {
+				$after_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $after_handle );
+				$do_concat = false;
+			}
 
 			// Allow plugins to disable concatenation of certain scripts.
 			$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -68,16 +68,6 @@ class WPcom_JS_Concat extends WP_Scripts {
 			$js_url_parsed = parse_url( $js_url );
 			$extra = $obj->extra;
 
-			// Check for scripts added from wp_add_inline_script()
-			$before_handle = $this->print_inline_script( $handle, 'before', false );
-			$after_handle = $this->print_inline_script( $handle, 'after', false );
-			if ( $before_handle ) {
-				$before_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $before_handle );
-			}
-			if ( $after_handle ) {
-				$after_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $after_handle );
-			}
-
 			// Don't concat by default
 			$do_concat = false;
 
@@ -98,6 +88,18 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$do_concat = false;
 			else
 				$js_url_parsed['path'] = substr( $js_realpath, strlen( ABSPATH ) - 1 );
+
+            // Check for scripts added from wp_add_inline_script()
+            $before_handle = $this->print_inline_script( $handle, 'before', false );
+            $after_handle = $this->print_inline_script( $handle, 'after', false );
+            if ( $before_handle ) {
+                $do_concat = false;
+                $before_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $before_handle );
+            }
+            if ( $after_handle ) {
+                $after_handle = sprintf( "<script type='text/javascript'>\n%s\n</script>\n", $after_handle );
+                $do_concat = false;
+            }
 
 			// Allow plugins to disable concatenation of certain scripts.
 			$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );


### PR DESCRIPTION
## Description
When certain js files are run through the existing concatenation on VIP Go, some are not properly rendered which breaks things in the Gutenberg editor. This fix skips concatenation for any files that add line script via `wp_add_inline_script()`

## Pros
Gutenberg works

## Cons
Performance can be slightly affected when less files are concatenated

## Steps to Test
See https://github.com/Automattic/vip-go-mu-plugins/pull/985