### PR TITLE
Skip core scripts that use Strict Mode

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -112,6 +112,11 @@ class WPcom_JS_Concat extends WP_Scripts {
 			if ( $this->has_inline_content( $handle ) ) {
 				$do_concat = false;
 			}
+			
+			// Skip core scripts that use Strict Mode
+			if ( 'react' === $handle || 'react-dom' === $handle ) {
+				$do_concat = false;
+			}
 
 			// Allow plugins to disable concatenation of certain scripts.
 			$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );


### PR DESCRIPTION
Disables concatenation for the two core javascript files that use strict mode.

> This syntax [use strict] has a trap that has already bitten a major site: it isn’t possible to blindly concatenate conflicting scripts. Consider concatenating a strict mode script with a non-strict mode script: the entire concatenation looks strict! The inverse is also true: non-strict plus strict looks non-strict.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Strict_mode

Related: https://github.com/Automattic/vip-go-mu-plugins/pull/1371