### PR TITLE
Wrap each javascript into their own function to prevent strict mode from leaking to other scripts

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -217,9 +217,11 @@ foreach ( $args as $uri ) {
 	}
 
 	if ( 'application/x-javascript' == $mime_type ) {
+		$output .= "$buf;\n";
+	} else if ( $concat_types['js'] == $mime_type ) {
 		$output .= "(function(window, document, undefined) {\n";
 		$output .= $buf;
-		$output .= "\n})(window, document);\n";
+		$output .= "\n}).call(this, window, document);\n";
 	} else {
 		$output .= "$buf";
 	}


### PR DESCRIPTION
This PR adds a prefix and suffix to all js scripts concatenated together, so that we don't end up with errors due to scripts starting with `"use strict";`.

Prefix:
```
(function(window, document, undefined) {
```

Suffix:
```
}).call(this, window, document);
```
