### PR TITLE
Fix implode order of arguments for PHP 7.4

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -119,7 +119,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 				} elseif ( count( $css ) > 1) {
 					$paths = array_map( function( $url ) { return ABSPATH . $url; }, $css );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( $css, ',' ) . "?m={$mtime}";
+					$path_str = implode( ',', $css ) . "?m={$mtime}";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -150,7 +150,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1) {
 					$paths = array_map( function( $url ) { return ABSPATH . $url; }, $js_array['paths'] );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( $js_array['paths'], ',' ) . "?m=${mtime}j";
+					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}j";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );


### PR DESCRIPTION
The `glue` argument should be the first one when calling `implode`. PHP 7.4 finally deprecates the option to put the glue as the second argument. This PR fixes a couple of places where the argument was placed incorrectly.