### PR TITLE
Add Core's script_loader_tag filter for scripts

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -172,7 +172,10 @@ class WPcom_JS_Concat extends WP_Scripts {
 					}
 				}
 				if ( isset( $href ) ) {
-					echo "<script type='text/javascript' src='$href'></script>\n";
+					$tag = "<script type='text/javascript' src='$href'></script>\n";
+					// Allow
+					$tag = apply_filters( 'script_loader_tag', $tag, $js_array, $href );
+					echo $tag;
 				}
 				if ( isset( $js_array['extras']['after'] ) ) {
 					foreach ( $js_array['extras']['after'] as $inline_after ) {

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -173,7 +173,13 @@ class WPcom_JS_Concat extends WP_Scripts {
 				}
 				if ( isset( $href ) ) {
 					$tag = "<script type='text/javascript' src='$href'></script>\n";
-					// Allow
+					/**
+					 * Filters the HTML script tag of an enqueued script.
+					 * 
+					 * @param string $tag        The `<script>` tag for the enqueued script.
+					 * @param string $js_array   The array with the type, path, and handles for the scripts being concatenated.
+					 * @param string $href       The script's source URL.
+					 */
 					$tag = apply_filters( 'script_loader_tag', $tag, $js_array, $href );
 					echo $tag;
 				}


### PR DESCRIPTION
## Problem
There is no way to filter our concatenated scripts and add things like `async`, `defer`, or other valid script attributes.

@rinatkhaziev had a good suggestion in this PR: https://github.com/Automattic/nginx-http-concat/pull/38

I actually worked based on that to start and had a WIP based on that code, but then realized that Core already has this filtering in place with `script_loader_tag`, and in fact plugins and themes rely on this script to be able to do things like this.  

Here's an example of Twentytwenty and how it uses this filter to add `async` and `defer`: 
https://github.com/WordPress/twentytwenty/blob/6d0a5240af108d02f58ec797fd49b32458a4c698/classes/class-twentytwenty-script-loader.php#L31

I think instead of adding a new filter, bringing in what Core already does into this would be better because it has more support from things already being used. 