### PR TITLE
Handle scripts without sources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,5 +30,5 @@ before_script:
     if [[ ${TRAVIS_PHP_VERSION:0:3} == "7.2" ]]; then
       composer global require "phpunit/phpunit:^7"
     else
-      composer global require "phpunit/phpunit:^4"
+      composer global require "phpunit/phpunit:^5.4"
     fi

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -74,9 +74,10 @@ class WPcom_JS_Concat extends WP_Scripts {
 			}
 
 			if ( ! $this->registered[$handle]->src ) { // Defines a group.
-				// if there are localized items, echo them
-				$this->print_extra_script( $handle );
-				$this->done[] = $handle;
+				if ( $this->do_item( $handle, $group ) ) {
+					$this->done[] = $handle;
+				}
+
 				continue;
 			}
 


### PR DESCRIPTION
As explained in #61, a script with a source set to `false` but that has inline scripts is broken because its inline scripts aren't output.

Fixes #61