### PR TITLE
match import rules containing semi-colons

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -197,7 +197,7 @@ foreach ( $args as $uri ) {
 		// Only @charset rule are allowed before them.
 		if ( false !== strpos( $buf, '@import' ) ) {
 			$buf = preg_replace_callback(
-				'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*;)/i',
+				'/(?P<pre_path>@import\s+(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*\W;)/i',
 				function ( $match ) use ( $dirpath ) {
 					global $pre_output;
 


### PR DESCRIPTION
The regex does not properly match `import` declarations if the URL contains a semi-colon. Example:

```
@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&family=Source+Sans+Pro:ital,wght@0,300;0,400;1,300;1,400&display=swap");
```

In this case, the regex will leave this at the top of the concatenated css file:

```
@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;
```

The unclosed statement then eats whatever follows, potentially accidentally closed by coincidence of other CSS.

The regex change ensures a non-word character before the declaration-ending `;`.

----

I enqueued and tested against a stylesheet with the following contents:

```
@import url("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap");
@import url('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap');
@import url ("https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap");
@import url ('https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap');
@import "https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap";
@import 'https://fonts.googleapis.com/css2?family=Roboto:ital,wght@0,300;0,400;0,700;1,300;1,400;1,700&display=swap';


body:before {
	content: "testing";
}

@import url("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap");
@import url('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap');
@import url ("https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap");
@import url ('https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap');
@import "https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap";
@import 'https://fonts.googleapis.com/css2?family=Source+Sans+Pro:ital&display=swap';


body {
	background: purple !important;
}
``` 