### PR TITLE
Improve @import declarations handling

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -197,7 +197,7 @@ foreach ( $args as $uri ) {
 		// Only @charset rule are allowed before them.
 		if ( false !== strpos( $buf, '@import' ) ) {
 			$buf = preg_replace_callback(
-				'/(?P<pre_path>@import\s{0,}(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*\W;)/i',
+				'/(?P<pre_path>@import\b\s{0,}(?:url\s*\()?[\'"\s]*)(?P<path>[^\'"\s](?:https?:\/\/.+\/?)?.+?)(?P<post_path>[\'"\s\)]*\W;)/i',
 				function ( $match ) use ( $dirpath ) {
 					global $pre_output;
 


### PR DESCRIPTION
The regex does not properly match @import declarations if the string contains no whitespace. Example:

```
@import"https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap”;
```

In this case, the regex does not recognize the `@import` and the rule is left in place in the concatenated file. If the `@import` rule is not at the top of the concatenated file (after `@charset`) then the `@import` fails.

The commit changes the regex from looking for a single space (`\s`) to looking for zero or one space (`\s?`). 

I tested this with the following `@import` rules and all were moved to the top of the concatenated file as expected: 

```
@import"https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap”;
@import'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap';
@import "https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap”;
@import 'https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap';
@import url("https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap");
@import url('https://fonts.googleapis.com/css2?family=Open+Sans:wght@300;400;500;700&display=swap');
```

#155191-z

[BB8-9691]