### PR TITLE
Fix/move charset top

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -177,16 +177,13 @@ foreach ( $args as $uri ) {
 
 		// The @charset rules must be on top of the output
 		if ( false !== strpos( $buf, '@charset' ) ) {
-			preg_replace_callback(
+			$buf = preg_replace_callback(
 				'/(?P<charset_rule>@charset\s+[\'"][^\'"]+[\'"];)/i',
 				function ( $match ) {
-					global $pre_output, $buf;
+					global $pre_output;
 
 					if ( 0 === strpos( $pre_output, '@charset' ) )
 						return '';
-
-					//strip $match[0] from $buf before adding $match[0] to beginning of $pre_output
-					$buf = str_replace($match[0], "", $buf);
 					
 					$pre_output = $match[0] . "\n" . $pre_output;
 


### PR DESCRIPTION
`@charset` must be on the first line of the concatenated file. However, the current code checks if `@charset` is already at position `0` (at the very beginning of the file). Only if `@charset` is already at the beginning will the code then attempt to move it to the beginning (where it already is located).

This PR changes `if ( 0 === strpos( $buf, '@charset' ) ) {` to `false !== strpos( $buf, '@charset' )` so that it checks if `@charset` is present anywhere in $buf. Then it deletes the instance of `@charset` from `$buf` before the existing code adds the `@charset` to the beginning of $buf. Otherwise, we end up with multiple `@charset` declarations in the concatenated file. There may be better ways to avoid this.

The following is an example of how I tested this:

style1.css:
```
body  {
	font-size: 12px;
}
```

style2.css:

```
.span {
	color: #fff;
}
@charset "UTF-8";
.class {
	color: #000;
}
```

With the current code the code the concatenated file looks like:

```
body{font-size: 12px}@charset "UTF-8";.span {color: #fff}.class {color: #000}
```
Notice the current code does move `@charset`, but to the top of the contents of the original file, not the top of the concatenated file. 

With the commits in this PR the concatenated file would like like:

```
@charset "UTF-8";
body{font-size: 12px}.span {color: #fff}.class {color: #000}
```

With my first commit but without my second commit (86331aa) it looked like:

```
@charset "UTF-8";
body{font-size: 12px}@charset "UTF-8";.span {color: #fff}.class {color: #000}
```

Hope this is helpful!