### PR TITLE
PHP 8.1: fix passing null to non-nullable deprecation

### DIFF
--- a/concat-utils.php
+++ b/concat-utils.php
@@ -24,7 +24,7 @@ class WPCOM_Concat_Utils {
 		$url_path = parse_url( $url, PHP_URL_PATH );
 		$site_url_path = parse_url( $site_url, PHP_URL_PATH );
 		// To avoid partial matches; subdir install at `/wp` would match `/wp-includes`
-		$site_url_path = trailingslashit( $site_url_path );
+		$site_url_path = is_null( $site_url_path ) ? '/' : trailingslashit( $site_url_path );
 
 		// If this is a subdirectory site, we need to strip off the subdir from the URL.
 		// In a multisite install, the subdir is virtual and therefore not needed in the path.


### PR DESCRIPTION
It seems `rtrim()` expects to be passed a non-nullable string on PHP 8.1. Passing `null` results `rtrim(): Passing null to parameter #1 ($string) of type string is deprecated` notice.

Ref:
* https://wiki.php.net/rfc/deprecate_null_to_scalar_internal_arg