### PR TITLE
Fix: Address deprecated variable format

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -151,7 +151,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				if ( isset( $js_array['paths'] ) && count( $js_array['paths'] ) > 1) {
 					$paths = array_map( function( $url ) { return ABSPATH . $url; }, $js_array['paths'] );
 					$mtime = max( array_map( 'filemtime', $paths ) );
-					$path_str = implode( ',', $js_array['paths'] ) . "?m=${mtime}j";
+					$path_str = implode( ',', $js_array['paths'] ) . "?m={$mtime}j";
 
 					if ( $this->allow_gzip_compression ) {
 						$path_64 = base64_encode( gzcompress( $path_str ) );


### PR DESCRIPTION
Addresses a PHP deprecation message that appears for PHP 8.2:

> Using ${var} in strings is deprecated, use {$var} instead.