### PR TITLE
Fix inline scripts breaking when using jQuery on empty source scripts

### DIFF
--- a/jsconcat.php
+++ b/jsconcat.php
@@ -73,7 +73,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				continue;
 			}
 
-			if ( ! $this->registered[$handle]->src ) { // Defines a group.
+			if ( ! $this->registered[$handle]->src && ! $this->has_inline_content( $handle ) ) { // Defines a group.
 				if ( $this->do_item( $handle, $group ) ) {
 					$this->done[] = $handle;
 				}
@@ -172,16 +172,16 @@ class WPcom_JS_Concat extends WP_Scripts {
 						echo $inline_before;
 					}
 				}
-			
+
 				// Allowed attributes taken from: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
-				$allowed_attributes = array( 
-					'async', 
-					'defer', 
-					'nomodule', 
-					'crossorigin', 
-					'integrity', 
-					'type', 
-					'nonce', 
+				$allowed_attributes = array(
+					'async',
+					'defer',
+					'nomodule',
+					'crossorigin',
+					'integrity',
+					'type',
+					'nonce',
 					'referrerpolicy'
 				);
 				$attr_string = '';
@@ -197,7 +197,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				 */
 				foreach ( (array) apply_filters( 'js_concat_script_attributes', [], $href, $js_array, $this ) as $k => $v ) {
 					if ( is_int( $k ) && in_array( $v, $allowed_attributes ) ) {
-						$attr_string .= sprintf( ' %s', esc_attr( $v ) );	
+						$attr_string .= sprintf( ' %s', esc_attr( $v ) );
 					} else if ( array_search( $k, $allowed_attributes ) ){
 						$attr_string .= sprintf( ' %s="%s"', sanitize_key( is_int( $k ) ? $v : $k ), esc_attr( $v ) );
 					}


### PR DESCRIPTION
## Expected/Desired Behavior

Scripts registered/enqueued without a source should add inline scripts after jQuery has been enqueued.

## Actual Behavior

Registering a dummy script without a `src` and using [wp_add_inline_script()](https://developer.wordpress.org/reference/functions/wp_add_inline_script/) adds to DOM before jQuery is loaded. 

For example, the plugin PublishPress Capabilities registers a dummy script to attach an inline script using jQuery: https://github.com/publishpress/PublishPress-Capabilities/blob/06000a5be5f896e0f3cdcbe3990afe9310243e90/includes/functions-admin.php#L266-L271

The current logic processes empty src scripts before jQuery is defined. This adds an extra check within the first group definition to not process scripts that contain inline content, which is also later checked at line 113: https://github.com/Automattic/nginx-http-concat/blob/73dbe08af00a92b91977d5eb9fb0d92b5f5c0909/jsconcat.php#L113-L115

## Steps to Reproduce

Add this code to register a dummy script with an inline jQuery script:

```
add_action('wp_enqueue_scripts', 'http_concat_inline_scripts') 

function http_concat_inline_scripts() {
    wp_register_script('dummy-script', false, ['jquery'] );
    wp_enqueue_script('dummy-script', false, ['jquery'] );
    wp_add_inline_script('dummy-script', 'jQuery.ready(function(){console.log("jQuery is defined")});');
};
```

Load the page and check browser dev tools to find the jQuery is not defined error.