### PR TITLE
break up asset groups of over 150

### DIFF
--- a/concat-utils.php
+++ b/concat-utils.php
@@ -1,14 +1,14 @@
 <?php
-
-if ( ! defined( 'VIP_CONCAT_MAX' ) ) {
-	define( 'VIP_CONCAT_MAX', 150 );
-}
-
 class WPCOM_Concat_Utils {
+	protected static int $concat_max = 150;
 
 	public static function get_concat_max() {
 		// no less than 10, no more than 150
-		return min( max( intval( VIP_CONCAT_MAX ), 10 ), 150 );
+		return min( max( intval( self::$concat_max ), 10 ), 150 );
+	}
+
+	public static function set_concat_max( int $max ) {
+		self::$concat_max = $max;
 	}
 
 	public static function is_internal_url( $test_url, $site_url ) {

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -3,12 +3,7 @@ class WPCOM_Concat_Utils {
 	protected static int $concat_max = 150;
 
 	public static function get_concat_max() {
-		// no less than 10, no more than 150
-		return min( max( intval( self::$concat_max ), 10 ), 150 );
-	}
-
-	public static function set_concat_max( int $max ) {
-		self::$concat_max = $max;
+		return self::$concat_max;
 	}
 
 	public static function is_internal_url( $test_url, $site_url ) {

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -5,6 +5,12 @@ if ( ! defined( 'VIP_CONCAT_MAX' ) ) {
 }
 
 class WPCOM_Concat_Utils {
+
+	public static function get_concat_max() {
+		// no less than 10, no more than 150
+		return min( max( intval( VIP_CONCAT_MAX ), 10 ), 150 );
+	}
+
 	public static function is_internal_url( $test_url, $site_url ) {
 		$test_url_parsed = parse_url( is_string( $test_url ) ? $test_url : '' );
 		$site_url_parsed = parse_url( $site_url );

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'VIP_CONCAT_MAX' ) ) {
+	define( 'VIP_CONCAT_MAX', 150 );
+}
+
 class WPCOM_Concat_Utils {
 	public static function is_internal_url( $test_url, $site_url ) {
 		$test_url_parsed = parse_url( is_string( $test_url ) ? $test_url : '' );

--- a/concat-utils.php
+++ b/concat-utils.php
@@ -1,5 +1,6 @@
 <?php
 class WPCOM_Concat_Utils {
+	// Maximum group size, anything over that will be split into multiple groups
 	protected static int $concat_max = 150;
 
 	public static function get_concat_max() {

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -99,7 +99,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url_parsed['path'];
 
-				if ( count( $stylesheets[ $stylesheet_group_index ][ $media ] ) > 100 ) {
+				if ( count( $stylesheets[ $stylesheet_group_index ][ $media ] ) >= VIP_CONCAT_MAX ) {
 					$stylesheet_group_index++;
 				}
 				$this->done[] = $handle;

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -98,6 +98,10 @@ class WPcom_CSS_Concat extends WP_Styles {
 					$stylesheets[ $stylesheet_group_index ] = array();
 
 				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url_parsed['path'];
+
+				if ( count( $stylesheets[ $stylesheet_group_index ][ $media ] ) > 100 ) {
+					$stylesheet_group_index++;
+				}
 				$this->done[] = $handle;
 			} else {
 				$stylesheet_group_index++;

--- a/cssconcat.php
+++ b/cssconcat.php
@@ -99,7 +99,7 @@ class WPcom_CSS_Concat extends WP_Styles {
 
 				$stylesheets[ $stylesheet_group_index ][ $media ][ $handle ] = $css_url_parsed['path'];
 
-				if ( count( $stylesheets[ $stylesheet_group_index ][ $media ] ) >= VIP_CONCAT_MAX ) {
+				if ( count( $stylesheets[ $stylesheet_group_index ][ $media ] ) >= WPCOM_Concat_Utils::get_concat_max() ) {
 					$stylesheet_group_index++;
 				}
 				$this->done[] = $handle;

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -129,6 +129,10 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$javascripts[$level]['paths'][] = $js_url_parsed['path'];
 				$javascripts[$level]['handles'][] = $handle;
 
+				if ( count( $javascripts[$level]['paths'] ) > 100 ) {
+					$level++;
+				}
+
 			} else {
 				$level++;
 				$javascripts[$level]['type'] = 'do_item';

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -129,7 +129,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$javascripts[$level]['paths'][] = $js_url_parsed['path'];
 				$javascripts[$level]['handles'][] = $handle;
 
-				if ( count( $javascripts[$level]['paths'] ) > 100 ) {
+				if ( count( $javascripts[$level]['paths'] ) >= VIP_CONCAT_MAX ) {
 					$level++;
 				}
 

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -129,7 +129,7 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$javascripts[$level]['paths'][] = $js_url_parsed['path'];
 				$javascripts[$level]['handles'][] = $handle;
 
-				if ( count( $javascripts[$level]['paths'] ) >= VIP_CONCAT_MAX ) {
+				if ( count( $javascripts[$level]['paths'] ) >= WPCOM_Concat_Utils::get_concat_max() ) {
 					$level++;
 				}
 

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -16,14 +16,12 @@ require_once( __DIR__ . '/cssmin/cssmin.php' );
 require_once( __DIR__ . '/concat-utils.php' );
 
 /* Config */
-// Maximum group size, anything over than that will be broken up into multiple groups
-$concat_max = 150;
+// Maximum group size is set in WPCOM_Concat_Utils::$concat_max, anything over than that will be spit into multiple groups
 $concat_unique = true;
 $concat_types = array(
 	'css' => 'text/css',
 	'js' => 'application/javascript'
 );
-WPCOM_Concat_Utils::set_concat_max( $concat_max );
 
 /* Constants */
 // By default determine the document root from this scripts path in the plugins dir (you can hardcode this define)

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -113,7 +113,7 @@ if ( ! $args )
 	concat_http_status_exit( 400 );
 
 // array( '/foo/bar.css', '/foo1/bar/baz.css' )
-if ( 0 == count( $args ) || count( $args ) > VIP_CONCAT_MAX )
+if ( 0 == count( $args ) || count( $args ) > WPCOM_Concat_Utils::get_concat_max() )
 	concat_http_status_exit( 400 );
 
 // If we're in a subdirectory context, use that as the root.

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -16,11 +16,14 @@ require_once( __DIR__ . '/cssmin/cssmin.php' );
 require_once( __DIR__ . '/concat-utils.php' );
 
 /* Config */
+// Maximum group size, anything over than that will be broken up into multiple groups
+$concat_max = 150;
 $concat_unique = true;
 $concat_types = array(
 	'css' => 'text/css',
 	'js' => 'application/javascript'
 );
+WPCOM_Concat_Utils::set_concat_max( $concat_max );
 
 /* Constants */
 // By default determine the document root from this scripts path in the plugins dir (you can hardcode this define)

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -16,7 +16,6 @@ require_once( __DIR__ . '/cssmin/cssmin.php' );
 require_once( __DIR__ . '/concat-utils.php' );
 
 /* Config */
-$concat_max_files = 150;
 $concat_unique = true;
 $concat_types = array(
 	'css' => 'text/css',
@@ -114,7 +113,7 @@ if ( ! $args )
 	concat_http_status_exit( 400 );
 
 // array( '/foo/bar.css', '/foo1/bar/baz.css' )
-if ( 0 == count( $args ) || count( $args ) > $concat_max_files )
+if ( 0 == count( $args ) || count( $args ) > VIP_CONCAT_MAX )
 	concat_http_status_exit( 400 );
 
 // If we're in a subdirectory context, use that as the root.


### PR DESCRIPTION
If there are more than 150 files in a single concatenated asset, it returns a 400 with no other error. We can proactively break up these large groups.

https://github.com/Automattic/nginx-http-concat/blob/585e97b5b0edaaff5e4197fe0083d418cb12acdf/ngx-http-concat.php#L19

https://github.com/Automattic/nginx-http-concat/blob/585e97b5b0edaaff5e4197fe0083d418cb12acdf/ngx-http-concat.php#L117-L118