### PR TITLE
CI updates: add svn, bump workflow versions.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,10 @@ jobs:
       - name: Check out source code
         uses: actions/checkout@v3
 
+      - name: Install svn
+        run: sudo apt-get update && sudo apt-get install -y subversion
+        shell: bash
+
       - name: Set up PHP
         uses: shivammathur/setup-php@2.22.0
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,6 @@ jobs:
       fail-fast: false
       matrix:
         php:
-          - '7.4'
           - '8.0'
           - '8.1'
           - '8.2'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
         php:
           - '7.4'
           - '8.0'
+          - '8.1'
+          - '8.2'
+          - '8.3'
         wp:
           - latest
         multisite:
           - 'no'
         include:
-          - php: '7.4'
+          - php: '8.1'
             wp: latest
             multisite: yes
     services:
@@ -45,17 +48,17 @@ jobs:
         shell: bash
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.22.0
+        uses: shivammathur/setup-php@2.32.0
         with:
           php-version: ${{ matrix.php }}
         env:
           fail-fast: 'true'
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@2.1.1
+        uses: ramsey/composer-install@3.0.0
 
       - name: Set up WordPress and WordPress Test Library
-        uses: sjinks/setup-wordpress-test-library@1.1.11
+        uses: sjinks/setup-wordpress-test-library@v2.1.3
         with:
           version: ${{ matrix.wp }}
 


### PR DESCRIPTION
This PR modernizes the CI infra:

1. include svn into build steps - the latest GH runners don't have that
2. PH: Drop 7.4, add all the way up to 8.3
3. Bump dependency actions.