### PR TITLE
Only concat concatable scripts and styles

### DIFF
--- a/cssconcat.php
+++ b/cssconcat.php
@@ -87,8 +87,11 @@ class WPcom_CSS_Concat extends WP_Styles {
 			else
 				$css_url_parsed['path'] = substr( $css_realpath, strlen( ABSPATH ) - 1 );
 
-			// Allow plugins to disable concatenation of certain stylesheets.
-			$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
+			// Only allow filter for anything that is currently concat'ing
+			// Stylesheets which are not concat'able should stay that way
+			if ( true === $do_concat ) {
+				$do_concat = apply_filters( 'css_do_concat', $do_concat, $handle );
+			}
 
 			if ( true === $do_concat ) {
 				$media = $obj->args;

--- a/jsconcat.php
+++ b/jsconcat.php
@@ -119,8 +119,11 @@ class WPcom_JS_Concat extends WP_Scripts {
 				$do_concat = false;
 			}
 
-			// Allow plugins to disable concatenation of certain scripts.
-			$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );
+			// Only allow filter for anything that is currently concat'ing
+			// Scripts which are not concat'able should stay that way
+			if ( true === $do_concat ) {
+				$do_concat = apply_filters( 'js_do_concat', $do_concat, $handle );
+			}
 
 			if ( true === $do_concat ) {
 				if ( !isset( $javascripts[$level] ) )


### PR DESCRIPTION
## Expected Behavior

Only scripts and assets that are concatable should be allowed to be overridden by the `css_do_concat` and `js_do_concat` filters.

## Actual Behavior

Both filters don't take into consideration whether a script/asset is concatable. One example is:
https://github.com/Automattic/nginx-http-concat/blob/master/jsconcat.php#L100-L103

Where you could attempt to concat an external script.

## Steps to Reproduce

The simplest way to reproduce is adding:
```php
add_filter( 'js_do_concat', '__return_true' );
// or
add_filter( 'css_do_concat', '__return_true' );
```

