### PR TITLE
Add newrelic_ignore_transaction to ngx-http-concat endpoint

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -15,6 +15,10 @@
 require_once( __DIR__ . '/cssmin/cssmin.php' );
 require_once( __DIR__ . '/concat-utils.php' );
 
+if ( extension_loaded( 'newrelic' ) ) { // Ensure PHP agent is available
+	newrelic_ignore_transaction();
+}
+
 /* Config */
 // Maximum group size is set in WPCOM_Concat_Utils::$concat_max, anything over than that will be spit into multiple groups
 $concat_unique = true;


### PR DESCRIPTION
Matching PR from the go-mu-plugins repo

This PR aims to remove platform required transactions from observation in New Relic

https://github.com/Automattic/vip-go-mu-plugins/pull/6279