### PR TITLE
Protect against already minified files causing timeouts

### DIFF
--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -230,8 +230,7 @@ foreach ( $args as $uri ) {
 		if ( ! $is_likely_minified ) {
 			$buf = $css_minify->run( $buf );
 		} elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
-			$safe_uri = rawurlencode( $uri );
-			error_log( 'ngx-http-concat: The file ' . $safe_uri . ' appears to be already minified, skipping minification step.' );
+			error_log( sprintf( 'ngx-http-concat: The file %s appears to be already minified, skipping minification step.', rawurlencode( $uri ) ) );
 		}
 	}
 

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -181,6 +181,17 @@ foreach ( $args as $uri ) {
 		// url(relative/path/to/file) -> url(/absolute/and/not/relative/path/to/file)
 		$buf = WPCOM_Concat_Utils::relative_path_replace( $buf, $dirpath );
 
+		// Try to detect if this is a likely minified file by looking at the average line length.
+		// If it's over 500 chars, we consider it minified and skip the minification step to avoid
+		// attempts to minify already minified files, which can cause long processing times and timeouts.
+		$lines = explode( "\n", $buf );
+		$avg_line_length = strlen( $buf ) / count( $lines );
+		if ( $avg_line_length > 500 ) {
+			$output .= $buf;
+			_doing_it_wrong( __FILE__, 'The file ' . $uri . ' appears to be already minified, skipping minification step.', false );
+			continue;
+		}
+
 		// The @charset rules must be on top of the output
 		if ( 0 === strpos( $buf, '@charset' ) ) {
 			preg_replace_callback(

--- a/ngx-http-concat.php
+++ b/ngx-http-concat.php
@@ -184,13 +184,10 @@ foreach ( $args as $uri ) {
 		// Try to detect if this is a likely minified file by looking at the average line length.
 		// If it's over 500 chars, we consider it minified and skip the minification step to avoid
 		// attempts to minify already minified files, which can cause long processing times and timeouts.
-		$lines = explode( "\n", $buf );
-		$avg_line_length = strlen( $buf ) / count( $lines );
-		if ( $avg_line_length > 500 ) {
-			$output .= $buf;
-			_doing_it_wrong( __FILE__, 'The file ' . $uri . ' appears to be already minified, skipping minification step.', false );
-			continue;
-		}
+		$is_likely_minified = false;
+		$line_count         = substr_count( $buf, "\n" ) + 1;
+		$avg_line_length    = strlen( $buf ) / $line_count;
+		$is_likely_minified = $avg_line_length > 500;
 
 		// The @charset rules must be on top of the output
 		if ( 0 === strpos( $buf, '@charset' ) ) {
@@ -230,7 +227,12 @@ foreach ( $args as $uri ) {
 			);
 		}
 
-		$buf = $css_minify->run( $buf );
+		if ( ! $is_likely_minified ) {
+			$buf = $css_minify->run( $buf );
+		} elseif ( defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+			$safe_uri = rawurlencode( $uri );
+			error_log( 'ngx-http-concat: The file ' . $safe_uri . ' appears to be already minified, skipping minification step.' );
+		}
 	}
 
 	if ( 'application/javascript' == $mime_type )


### PR DESCRIPTION
If an already minified CSS file finds it's way into the minification process it can lead to huge processing times and even timeouts as the regexes involved choke on huge lines of minified CSS.

This change aims to protect against that scenario by introducing a heuristic that tries to skip any already minified files.