### PR TITLE
chore: update CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,14 @@ jobs:
           - '8.1'
           - '8.2'
           - '8.3'
+          - '8.4'
+          - '8.5'
         wp:
           - latest
         multisite:
           - 'no'
         include:
-          - php: '8.1'
+          - php: '8.4'
             wp: latest
             multisite: yes
     services:
@@ -40,24 +42,24 @@ jobs:
           MYSQL_DATABASE: wordpress_test
     steps:
       - name: Check out source code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v6
 
       - name: Install svn
         run: sudo apt-get update && sudo apt-get install -y subversion
         shell: bash
 
       - name: Set up PHP
-        uses: shivammathur/setup-php@2.32.0
+        uses: shivammathur/setup-php@v2
         with:
           php-version: ${{ matrix.php }}
         env:
           fail-fast: 'true'
 
       - name: Install PHP Dependencies
-        uses: ramsey/composer-install@3.0.0
+        uses: ramsey/composer-install@v3
 
       - name: Set up WordPress and WordPress Test Library
-        uses: sjinks/setup-wordpress-test-library@v2.1.3
+        uses: sjinks/setup-wordpress-test-library@v3.0.0
         with:
           version: ${{ matrix.wp }}
 


### PR DESCRIPTION
This pull request updates the CI workflow configuration to add support for newer PHP versions and modernizes the actions used in the workflow. The changes ensure compatibility with the latest PHP releases and improve maintainability by using up-to-date action versions.

**PHP version support updates:**

* Added PHP 8.4 and 8.5 to the test matrix, and updated the multisite test to run on PHP 8.4 instead of 8.1. (.github/workflows/ci.yml)

**CI workflow modernization:**

* Updated GitHub Actions to use newer versions: `actions/checkout` to v6, `shivammathur/setup-php` to v2, `ramsey/composer-install` to v3, and `sjinks/setup-wordpress-test-library` to v3.0.0. (.github/workflows/ci.yml)